### PR TITLE
Add Samples Index metadata for samples

### DIFF
--- a/analytics/.google/packaging.yaml
+++ b/analytics/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/configuration-apks/.google/packaging.yaml
+++ b/configuration-apks/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/configuration-apks/.google/packaging.yaml
+++ b/configuration-apks/.google/packaging.yaml
@@ -27,7 +27,7 @@ status:       PUBLISHED
 # See http://go/sample-categories
 technologies: [Android]
 categories:   [Instant Apps]
-languages:    [Java]
+languages:    [Kotlin]
 solutions:    [Mobile]
 
 # May be omitted if unpublished

--- a/cookie-api/.google/packaging.yaml
+++ b/cookie-api/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/cookie-api/.google/packaging.yaml
+++ b/cookie-api/.google/packaging.yaml
@@ -27,7 +27,7 @@ status:       PUBLISHED
 # See http://go/sample-categories
 technologies: [Android]
 categories:   [Instant Apps]
-languages:    [Java]
+languages:    [Kotlin]
 solutions:    [Mobile]
 
 # May be omitted if unpublished

--- a/flavors/.google/packaging.yaml
+++ b/flavors/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/hello-feature-module/.google/packaging.yaml
+++ b/hello-feature-module/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/hello-java/.google/packaging.yaml
+++ b/hello-java/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/hello-kotlin/.google/packaging.yaml
+++ b/hello-kotlin/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Kotlin]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/hello-kotlin/README.md
+++ b/hello-kotlin/README.md
@@ -1,4 +1,4 @@
-# Android Instant Apps - Hello World
+# Android Instant Apps - Hello World (Kotlin)
 
 This sample app demonstrates how to build an installed and an instant app
 with the same behaviors by using Kotlin.

--- a/install-api/.google/packaging.yaml
+++ b/install-api/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/install-api/.google/packaging.yaml
+++ b/install-api/.google/packaging.yaml
@@ -27,7 +27,7 @@ status:       PUBLISHED
 # See http://go/sample-categories
 technologies: [Android]
 categories:   [Instant Apps]
-languages:    [Java]
+languages:    [Kotlin]
 solutions:    [Mobile]
 
 # May be omitted if unpublished

--- a/multi-feature-module/.google/packaging.yaml
+++ b/multi-feature-module/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/service/.google/packaging.yaml
+++ b/service/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/storage-api/.google/packaging.yaml
+++ b/storage-api/.google/packaging.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GOOGLE SAMPLE PACKAGING DATA
+#
+# This file is used by Google as part of our samples packaging process.
+# End users may safely ignore this file. It has no relevance to other systems.
+---
+# Values: {DRAFT | PUBLISHED | INTERNAL | DEPRECATED | SUPERCEDED}
+status:       PUBLISHED
+
+# Optional, put additional explanation here for DEPRECATED or SUPERCEDED.
+# statusNote:
+
+# See http://go/sample-categories
+technologies: [Android]
+categories:   [Instant Apps]
+languages:    [Java]
+solutions:    [Mobile]
+
+# May be omitted if unpublished
+github:       googlesamples/android-instant-apps
+
+# Values: BEGINNER | INTERMEDIATE | ADVANCED | EXPERT
+level:        ADVANCED
+
+# Default: apache2. May be omitted for most samples.
+# Alternatives: apache2-android (for AOSP)
+license: apache2

--- a/storage-api/.google/packaging.yaml
+++ b/storage-api/.google/packaging.yaml
@@ -27,7 +27,7 @@ status:       PUBLISHED
 # See http://go/sample-categories
 technologies: [Android]
 categories:   [Instant Apps]
-languages:    [Java]
+languages:    [Kotlin]
 solutions:    [Mobile]
 
 # May be omitted if unpublished


### PR DESCRIPTION
Add .google/packaging.yaml file to each sample directory, so that the
samples can be picked up by Google's Samples Index system.

Also updated README.md for hello-kotlin sample to add "Kotlin" to the
sample's title.