### PR TITLE
Update install API sample to use Google APIs for Android

### DIFF
--- a/install-api/README.md
+++ b/install-api/README.md
@@ -1,6 +1,6 @@
 # Android Instant Apps - Install API sample
 
-This sample app demonstrates how to use the [Install API](https://developer.android.com/topic/instant-apps/reference.html#showinstallprompt).
+This sample app demonstrates how to use the [Install API](https://developers.google.com/android/reference/com/google/android/gms/instantapps/InstantApps.html#showInstallPrompt(android.app.Activity,%20android.content.Intent,%20int,%20java.lang.String)).
 
 The API triggers Intent to install the app on device.
 The call also accepts Intent, which is triggered after the installation is complete.

--- a/install-api/features/base/build.gradle
+++ b/install-api/features/base/build.gradle
@@ -47,5 +47,6 @@ dependencies {
     application project(":installed")
     feature project(':features:install')
     api "com.android.support:appcompat-v7:$supportLib"
+    api 'com.google.android.gms:play-services-instantapps:16.0.0'
 }
 

--- a/install-api/features/install/build.gradle
+++ b/install-api/features/install/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation project(':features:base')
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
 
-    implementation 'com.google.android.instantapps:instantapps:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     androidTestImplementation "com.android.support.test.espresso:espresso-core:$espressoVersion"

--- a/install-api/features/install/src/main/java/com/instantappsamples/feature/install/InstallApiActivity.kt
+++ b/install-api/features/install/src/main/java/com/instantappsamples/feature/install/InstallApiActivity.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.Button
-import com.google.android.instantapps.InstantApps
+import com.google.android.gms.instantapps.InstantApps
 
 /**
  * An Activity that shows usage of the Install API, [documented here](https://developer.android.com/topic/instant-apps/reference.html#showinstallprompt).
@@ -30,7 +30,7 @@ class InstallApiActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_install)
 
-        val isInstantApp = InstantApps.isInstantApp(this)
+        val isInstantApp = InstantApps.getPackageManagerCompat(this).isInstantApp();
 
         findViewById<Button>(R.id.start_installation).apply {
             isEnabled = isInstantApp


### PR DESCRIPTION
Tested by building the sample locally.

It shows install prompt as expected but FYI the installed app sample itself needs to be published for full E2E experience (no behavior change from existing sample).